### PR TITLE
Add NEUSEG GM/WM Contour / Nuclei Morphometrics overlay updates to slide UI

### DIFF
--- a/phas/slide.py
+++ b/phas/slide.py
@@ -812,22 +812,14 @@ def load_slide_into_cache(slide_id, sr, resource, socket_addr_list):
 
 # Discover GeoJSON overlays (e.g., contours) in the same directory as .svs
 def get_geojson_overlays(sr, slide_id, task_id):
-    """Find GeoJSON files matching {slide_name}_boundaries.geojson pattern."""
-    import glob
+    """Find GeoJSON contour overlays from neuseg_contour resource schema."""
     overlays = {}
     try:
-        # Get base path (histo_raw directory)
-        base_path = sr.get_resource_url('raw', True)  # Local file path
-        if base_path.endswith('.svs'):
-            base_path = base_path[:-4]  # Remove .svs extension
-        
-        # Search for matching GeoJSON files
-        pattern = base_path + '_boundaries.geojson'
-        for geojson_file in glob.glob(pattern):
-            overlay_name = os.path.basename(geojson_file).replace('.geojson', '')
-            overlays[overlay_name] = {
-                'name': overlay_name,
-                'url': url_for('slide.api_get_geojson_overlay', task_id=task_id, slide_id=slide_id, overlay_name=overlay_name)
+        contour_path = sr.get_resource_url('neuseg_contour', True)
+        if contour_path and os.path.exists(contour_path):
+            overlays['neuseg_contour'] = {
+                'name': 'GM/WM Contour',
+                'url': url_for('slide.api_get_geojson_overlay', task_id=task_id, slide_id=slide_id, overlay_name='neuseg_contour')
             }
     except:
         pass
@@ -836,28 +828,19 @@ def get_geojson_overlays(sr, slide_id, task_id):
 
 # Discover nuclei morphometric heatmaps in the same directory as .svs
 def resolve_nuclei_heatmap_path(sr, kind):
-    import glob
-    suffix_map = {
-        'density': '_soma_density_heatmap.png',
-        'size': '_soma_size_heatmap.png'
+    resource_map = {
+        'density': 'neuseg_density',
+        'size': 'neuseg_size'
     }
-    if kind not in suffix_map:
+    if kind not in resource_map:
         return None
 
-    base_path = sr.get_resource_url('raw', True)
-    base_root, _ = os.path.splitext(base_path)
-    suffix = suffix_map[kind]
-
-    # Prefer exact basename match with the raw slide.
-    direct_match = base_root + suffix
-    if os.path.exists(direct_match):
-        return direct_match
-
-    # Fallback: scan the slide directory for same suffix.
-    dir_path = os.path.dirname(base_path)
-    matches = sorted(glob.glob(os.path.join(dir_path, '*' + suffix)))
-    if matches:
-        return matches[0]
+    try:
+        f_neuseg = sr.get_resource_url(resource_map[kind], True)
+        if f_neuseg and os.path.exists(f_neuseg):
+            return f_neuseg
+    except:
+        pass
     return None
 
 
@@ -1396,13 +1379,13 @@ class PILBytesIO(BytesIO):
 @access_task_slide_read()
 def api_get_geojson_overlay(task_id, slide_id, overlay_name):
     _,_,sr = get_project_task_slide_ref(task_id, slide_id)
-    
-    # Construct GeoJSON file path
-    base_path = sr.get_resource_url('raw', True)
-    dir_path = os.path.dirname(base_path)
-    geojson_path = os.path.join(dir_path, overlay_name + '.geojson')
-    
-    if os.path.exists(geojson_path):
+
+    if overlay_name != 'neuseg_contour':
+        abort(404, f'Unsupported GeoJSON overlay: {overlay_name}')
+
+    geojson_path = sr.get_resource_url('neuseg_contour', True)
+
+    if geojson_path and os.path.exists(geojson_path):
         with open(geojson_path, 'r') as f:
             return Response(f.read(), mimetype='application/json')
     else:

--- a/phas/slide.py
+++ b/phas/slide.py
@@ -808,6 +808,81 @@ def get_available_tasks_for_slide(project, slide_id):
 def load_slide_into_cache(slide_id, sr, resource, socket_addr_list):
     osl = get_osl(slide_id, sr, resource, socket_addr_list)
     print(f'================== Slide {slide_id} has dimensions {osl.dimensions} ===================')
+
+
+# Discover GeoJSON overlays (e.g., contours) in the same directory as .svs
+def get_geojson_overlays(sr, slide_id, task_id):
+    """Find GeoJSON files matching {slide_name}_*.geojson pattern."""
+    import glob
+    overlays = {}
+    try:
+        # Get base path (histo_raw directory)
+        base_path = sr.get_resource_url('raw', True)  # Local file path
+        if base_path.endswith('.svs'):
+            base_path = base_path[:-4]  # Remove .svs extension
+        
+        # Search for matching GeoJSON files
+        pattern = base_path + '_*.geojson'
+        for geojson_file in glob.glob(pattern):
+            overlay_name = os.path.basename(geojson_file).replace('.geojson', '')
+            overlays[overlay_name] = {
+                'name': overlay_name,
+                'url': url_for('slide.api_get_geojson_overlay', task_id=task_id, slide_id=slide_id, overlay_name=overlay_name)
+            }
+    except:
+        pass
+    return overlays
+
+
+# Discover nuclei morphometric heatmaps in the same directory as .svs
+def resolve_nuclei_heatmap_path(sr, kind):
+    import glob
+    suffix_map = {
+        'density': '_soma_density_heatmap.png',
+        'size': '_soma_size_heatmap.png'
+    }
+    if kind not in suffix_map:
+        return None
+
+    base_path = sr.get_resource_url('raw', True)
+    base_root, _ = os.path.splitext(base_path)
+    suffix = suffix_map[kind]
+
+    # Prefer exact basename match with the raw slide.
+    direct_match = base_root + suffix
+    if os.path.exists(direct_match):
+        return direct_match
+
+    # Fallback: scan the slide directory for same suffix.
+    dir_path = os.path.dirname(base_path)
+    matches = sorted(glob.glob(os.path.join(dir_path, '*' + suffix)))
+    if matches:
+        return matches[0]
+    return None
+
+
+def get_nuclei_heatmap_overlays(sr, slide_id, task_id):
+    overlays = {}
+    name_map = {
+        'density': 'Nuclei Density',
+        'size': 'Nuclei Size'
+    }
+    try:
+        for kind, name in name_map.items():
+            if resolve_nuclei_heatmap_path(sr, kind):
+                overlays[kind] = {
+                    'name': name,
+                    'kind': kind,
+                    'url': url_for(
+                        'slide.api_get_nuclei_heatmap_overlay',
+                        task_id=task_id,
+                        slide_id=slide_id,
+                        kind=kind
+                    )
+                }
+    except:
+        pass
+    return overlays
         
 
 # The slide view
@@ -841,6 +916,10 @@ def slide_view(task_id, slide_id, resolution, affine_mode):
 
     # Get the list of available overlays and jsonify
     overlays = sr.get_available_overlays(local = False)
+    
+    # Get GeoJSON contour & Nuclei Morphometric overlays
+    geojson_overlays = get_geojson_overlays(sr, slide_id, task_id)
+    nuclei_heatmap_overlays = get_nuclei_heatmap_overlays(sr, slide_id, task_id)
     
     # Get the list of other tasks available for this slide
     other_tasks = get_available_tasks_for_slide(tr.project, slide_id)
@@ -912,6 +991,8 @@ def slide_view(task_id, slide_id, resolution, affine_mode):
         'user_prefs': user_prefs,
         'overlays': overlays,
         'other_tasks': other_tasks,
+        'geojson_overlays': geojson_overlays,
+        'nuclei_heatmap_overlays': nuclei_heatmap_overlays,
         'read_only': read_only,
         'download_size_limit' : tr.download_size_limit if tr.download_size_limit is not None else -1
     }
@@ -1308,6 +1389,40 @@ class PILBytesIO(BytesIO):
     def fileno(self):
         '''Classic PIL doesn't understand io.UnsupportedOperation.'''
         raise AttributeError('Not supported')
+
+
+# Serve GeoJSON overlay (contours, etc.)
+@bp.route('/api/task/<int:task_id>/slide/<int:slide_id>/geojson/<overlay_name>.json', methods=('GET',))
+@access_task_slide_read()
+def api_get_geojson_overlay(task_id, slide_id, overlay_name):
+    _,_,sr = get_project_task_slide_ref(task_id, slide_id)
+    
+    # Construct GeoJSON file path
+    base_path = sr.get_resource_url('raw', True)
+    dir_path = os.path.dirname(base_path)
+    geojson_path = os.path.join(dir_path, overlay_name + '.geojson')
+    
+    if os.path.exists(geojson_path):
+        with open(geojson_path, 'r') as f:
+            return Response(f.read(), mimetype='application/json')
+    else:
+        abort(404, f'GeoJSON overlay not found: {overlay_name}')
+
+
+# Serve nuclei morphometric heatmap image if available
+@bp.route('/api/task/<int:task_id>/slide/<int:slide_id>/nuclei_heatmap/<kind>.png', methods=('GET',))
+@access_task_slide_read()
+def api_get_nuclei_heatmap_overlay(task_id, slide_id, kind):
+    _, _, sr = get_project_task_slide_ref(task_id, slide_id)
+
+    if kind not in ('density', 'size'):
+        abort(404, f'Unsupported nuclei heatmap kind: {kind}')
+
+    heatmap_path = resolve_nuclei_heatmap_path(sr, kind)
+
+    if heatmap_path and os.path.exists(heatmap_path):
+        return send_file(heatmap_path, mimetype='image/png')
+    abort(404, f'Nuclei heatmap not found: {kind}')
 
 
 # Serve label image if available
@@ -1837,4 +1952,3 @@ def init_app(app):
     app.cli.add_command(export_task_annot_cmd)
     app.cli.add_command(import_task_annot_cmd)
     app.cli.add_command(annot_copy_to_task_cmd)
-

--- a/phas/slide.py
+++ b/phas/slide.py
@@ -812,7 +812,7 @@ def load_slide_into_cache(slide_id, sr, resource, socket_addr_list):
 
 # Discover GeoJSON overlays (e.g., contours) in the same directory as .svs
 def get_geojson_overlays(sr, slide_id, task_id):
-    """Find GeoJSON files matching {slide_name}_*.geojson pattern."""
+    """Find GeoJSON files matching {slide_name}_boundaries.geojson pattern."""
     import glob
     overlays = {}
     try:
@@ -822,7 +822,7 @@ def get_geojson_overlays(sr, slide_id, task_id):
             base_path = base_path[:-4]  # Remove .svs extension
         
         # Search for matching GeoJSON files
-        pattern = base_path + '_*.geojson'
+        pattern = base_path + '_boundaries.geojson'
         for geojson_file in glob.glob(pattern):
             overlay_name = os.path.basename(geojson_file).replace('.geojson', '')
             overlays[overlay_name] = {

--- a/phas/templates/slide/slide_view.html
+++ b/phas/templates/slide/slide_view.html
@@ -58,6 +58,99 @@
         margin: 0 5px 5px 5px;
         padding: 2px 0 2px 0;
         cursor: pointer;
+        display: inline-block;
+    }
+
+    button.geojson-toggle {
+        margin: 0 !important;
+        width: 100%;
+        box-sizing: border-box;
+        white-space: nowrap;
+        z-index: 1000;
+        position: static !important;
+        opacity: 1 !important;
+        visibility: visible !important;
+        display: inline-block !important;
+    }
+
+    .geojson-controls-stack {
+        position: fixed;
+        right: 10px;
+        bottom: 10px;
+        width: 220px;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        align-items: stretch;
+        z-index: 999;
+    }
+
+    .geojson-controls-stack .geojson-width-label {
+        font-weight: bold;
+        font-size: 14px;
+        background: white;
+        color: black;
+        padding: 5px 8px;
+        border-radius: 3px;
+        text-align: center;
+        width: 100%;
+        box-sizing: border-box;
+    }
+
+    .geojson-controls-stack .geojson-width-slider {
+        width: 100%;
+        vertical-align: middle;
+        margin: 0;
+    }
+
+    button.nuclei-toggle {
+        margin: 0 !important;
+        width: 100%;
+        box-sizing: border-box;
+        white-space: nowrap;
+    }
+
+    .nuclei-controls-stack {
+        position: fixed;
+        right: 10px;
+        bottom: 114px;
+        width: 220px;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        align-items: stretch;
+        z-index: 1001;
+    }
+
+    .nuclei-opacity-label {
+        font-weight: bold;
+        font-size: 14px;
+        background: white;
+        color: black;
+        padding: 5px 8px;
+        border-radius: 3px;
+        text-align: center;
+        box-sizing: border-box;
+    }
+
+    .nuclei-opacity-slider {
+        width: 100%;
+        margin: 0;
+        vertical-align: middle;
+    }
+
+    .nuclei-checkboxes {
+        background: white;
+        border-radius: 3px;
+        padding: 6px 8px;
+        box-sizing: border-box;
+    }
+
+    .nuclei-checkboxes label {
+        display: block;
+        font-size: 12px;
+        margin: 4px 0;
+        color: black;
     }
 
     button.enabled {
@@ -544,6 +637,32 @@
     {% endif %}
 {% endif %}
 
+{# Nuclei Morphometric heatmap controls #}
+{% if nuclei_heatmap_overlays %}
+<div class="nuclei-controls-stack">
+    <label class="nuclei-opacity-label" for="nuclei-opacity-slider">Opacity: <span id="nuclei-opacity-value">60</span>%</label>
+    <input type="range" class="nuclei-opacity-slider" id="nuclei-opacity-slider" min="0" max="100" step="1" value="60">
+    <button id="nuclei-morphometric-toggle" class="bottom_button enabled nuclei-toggle">&nbsp Nuclei Morphometric (N) &nbsp</button>
+    <div class="nuclei-checkboxes">
+        <label><input type="checkbox" class="nuclei-overlay-choice" value="density" {% if 'density' in nuclei_heatmap_overlays %}checked{% else %}disabled{% endif %}> Nuclei Density</label>
+        <label><input type="checkbox" class="nuclei-overlay-choice" value="size" {% if 'size' in nuclei_heatmap_overlays and 'density' not in nuclei_heatmap_overlays %}checked{% endif %} {% if 'size' not in nuclei_heatmap_overlays %}disabled{% endif %}> Nuclei Size</label>
+    </div>
+</div>
+{% endif %}
+
+{# GeoJSON overlay toggles #}
+{% if geojson_overlays %}
+    {% for overlay_name, overlay_info in geojson_overlays.items() %}
+    <div class="geojson-controls-stack">
+        <span class="geojson-width-label">Width: <span id="width-value">30</span>px</span>
+        <input type="range" class="geojson-width-slider" id="geojson-width-slider" min="0" max="60" step="0.5" value="30" data-overlay="{{ overlay_name }}">
+        <button class="bottom_button enabled geojson-toggle" data-overlay="{{ overlay_name }}">&nbsp GM/WM Contour (C) &nbsp</button>
+    </div>
+    {% endfor %}
+{% else %}
+<!-- DEBUG: geojson_overlays is empty or not defined -->
+{% endif %}
+
 <div id="hovertooltip">Hover text goes here</div>
 
 <script type="text/javascript">
@@ -565,6 +684,7 @@ $(document).ready(function()
     const init_rotation = user_prefs.rotation || 0;
     const init_flip = user_prefs.flip || false;
     const overlays = {{overlays|tojson}};
+    const nuclei_heatmap_overlays = {{nuclei_heatmap_overlays|tojson}};
     const other_tasks_dict = {{other_tasks|tojson}};
 
     // Common URLs
@@ -755,6 +875,9 @@ $(document).ready(function()
         // Does some important calibration of canvas and paperjs
         overlay.resize();
         overlay.resizecanvas();
+
+        // Load GeoJSON overlays after Paper.js is initialized
+        load_geojson_overlays();
 
         // Get the initial data
         if (seg_mode === 'annot') {
@@ -2728,6 +2851,20 @@ $(document).ready(function()
     Mousetrap.bind('j', function() { console.log(paper.project.exportJSON()) });
     Mousetrap.bind('D', function() { fn_raise_dl_dialog() });
     Mousetrap.bind('?', function() { help_dialog.dialog("open"); });
+    Mousetrap.bind(['c', 'C'], function() {
+        const btn = $(".geojson-toggle").first();
+        if(btn.length) {
+            btn.trigger("click");
+            return false;
+        }
+    });
+    Mousetrap.bind(['n', 'N'], function() {
+        const btn = $("#nuclei-morphometric-toggle");
+        if(btn.length) {
+            btn.trigger("click");
+            return false;
+        }
+    });
 
     // Also bind the download function to the download button
     $("#button_download").button();
@@ -3239,6 +3376,262 @@ $(document).ready(function()
         // Set the listener
         s_ovl.change(on_overlay_select);
     }
+
+    // Nuclei Morphometric Overlay Handling
+    let nuclei_overlay_element = null;
+    let nuclei_overlay_enabled = false;
+    let nuclei_selected_kind = null;
+    let nuclei_overlay_request_id = 0;
+
+    let remove_nuclei_overlay = function() {
+        if(nuclei_overlay_element) {
+            viewer.removeOverlay(nuclei_overlay_element);
+            $(nuclei_overlay_element).remove();
+            nuclei_overlay_element = null;
+        }
+    };
+
+    let get_first_available_nuclei_kind = function() {
+        let choice = $(".nuclei-overlay-choice:not(:disabled)").first();
+        return choice.length ? choice.val() : null;
+    };
+
+    let render_nuclei_overlay = function() {
+        remove_nuclei_overlay();
+
+        if(!nuclei_overlay_enabled || !nuclei_selected_kind || !nuclei_heatmap_overlays[nuclei_selected_kind]) {
+            return;
+        }
+
+        let base_item = viewer.world.getItemAt(0);
+        if(!base_item) {
+            return;
+        }
+
+        let cfg = nuclei_heatmap_overlays[nuclei_selected_kind];
+        let base_bounds = base_item.getBounds();
+        let base_content = base_item.getContentSize();
+        let opacity_percent = parseInt($("#nuclei-opacity-slider").val(), 10);
+        let opacity = opacity_percent / 100.0;
+        let req_id = ++nuclei_overlay_request_id;
+
+        // Downsample-aware mapping: detect downsample ratio from PNG size vs displayed base image size.
+        let detected_scale_x = (cfg.png_w && base_content.x) ? (base_content.x / cfg.png_w) : 1.0;
+        let detected_scale_y = (cfg.png_h && base_content.y) ? (base_content.y / cfg.png_h) : 1.0;
+        let mapped_w = (cfg.png_w || base_content.x) * detected_scale_x;
+        let mapped_h = (cfg.png_h || base_content.y) * detected_scale_y;
+        let w_frac = mapped_w / base_content.x;
+        let h_frac = mapped_h / base_content.y;
+        let overlay_rect = new OpenSeadragon.Rect(
+            base_bounds.x,
+            base_bounds.y,
+            base_bounds.width * w_frac,
+            base_bounds.height * h_frac
+        );
+
+        let overlay_img = document.createElement("img");
+        overlay_img.style.width = "100%";
+        overlay_img.style.height = "100%";
+        overlay_img.style.pointerEvents = "none";
+        overlay_img.style.opacity = opacity.toString();
+        overlay_img.alt = "Nuclei heatmap overlay";
+
+        overlay_img.onload = function() {
+            if(req_id !== nuclei_overlay_request_id || !nuclei_overlay_enabled || !nuclei_selected_kind) {
+                return;
+            }
+            viewer.addOverlay({
+                element: overlay_img,
+                location: overlay_rect,
+                checkResize: false
+            });
+            nuclei_overlay_element = overlay_img;
+        };
+
+        overlay_img.onerror = function() {
+            if(req_id === nuclei_overlay_request_id) {
+                window.alert("Nuclei heatmap overlay failed to load");
+            }
+        };
+
+        overlay_img.src = cfg.url;
+    };
+
+    if(nuclei_heatmap_overlays && Object.keys(nuclei_heatmap_overlays).length > 0) {
+        let checked_choice = $(".nuclei-overlay-choice:checked").first();
+        nuclei_selected_kind = checked_choice.length ? checked_choice.val() : get_first_available_nuclei_kind();
+        if(nuclei_selected_kind && checked_choice.length === 0) {
+            $(`.nuclei-overlay-choice[value=\"${nuclei_selected_kind}\"]`).prop("checked", true);
+        }
+
+        $(".nuclei-overlay-choice").on("change", function() {
+            if($(this).is(":checked")) {
+                $(".nuclei-overlay-choice").not(this).prop("checked", false);
+                nuclei_selected_kind = $(this).val();
+            } else {
+                let current_choice = $(".nuclei-overlay-choice:checked").first();
+                nuclei_selected_kind = current_choice.length ? current_choice.val() : null;
+            }
+
+            if(nuclei_overlay_enabled) {
+                if(nuclei_selected_kind) {
+                    render_nuclei_overlay();
+                } else {
+                    nuclei_overlay_enabled = false;
+                    $("#nuclei-morphometric-toggle").removeClass("active");
+                    remove_nuclei_overlay();
+                }
+            }
+        });
+
+        $("#nuclei-morphometric-toggle").on("click", function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+
+            if(!nuclei_overlay_enabled) {
+                if(!nuclei_selected_kind) {
+                    nuclei_selected_kind = get_first_available_nuclei_kind();
+                    if(nuclei_selected_kind) {
+                        $(`.nuclei-overlay-choice[value=\"${nuclei_selected_kind}\"]`).prop("checked", true);
+                    }
+                }
+                if(!nuclei_selected_kind) {
+                    return;
+                }
+                nuclei_overlay_enabled = true;
+                $(this).addClass("active");
+                render_nuclei_overlay();
+            } else {
+                nuclei_overlay_enabled = false;
+                $(this).removeClass("active");
+                remove_nuclei_overlay();
+            }
+        });
+
+        $("#nuclei-opacity-slider").on("input change", function() {
+            let opacity_percent = parseInt($(this).val(), 10);
+            $("#nuclei-opacity-value").text(opacity_percent);
+            if(nuclei_overlay_element) {
+                $(nuclei_overlay_element).css("opacity", opacity_percent / 100.0);
+            }
+        });
+    }
+
+    // GeoJSON Overlay Handling
+    const geojson_overlays = {{geojson_overlays|tojson}};
+    const geojson_layers = {};  // Store layer data by overlay name
+
+    // Draw GeoJSON LineStrings on the viewer using paper.js
+    function draw_geojson(geojson_data, overlay_name) {
+        if (!geojson_data.features) {
+            console.log('ERROR: No features in GeoJSON for', overlay_name, geojson_data);
+            return;
+        }
+
+        let overlay_group = new paper.Group({name: 'geojson_' + overlay_name});
+        let path_count = 0;
+
+        for (let feature of geojson_data.features) {
+            if (feature.geometry.type === 'LineString') {
+                let coords = feature.geometry.coordinates;
+                let stroke_color = feature.properties.stroke_color || '#00FF00';
+                let stroke_width = feature.properties.stroke_width || 2;
+
+                console.log('Drawing path:', feature.properties.contour_id, 'color:', stroke_color, 'width:', stroke_width, 'points:', coords.length);
+
+                // Convert pixel coordinates to paper.js coordinates
+                let path = new paper.Path({
+                    strokeColor: stroke_color,
+                    strokeWidth: stroke_width,
+                    closed: false,
+                    name: feature.properties.contour_id
+                });
+
+                for (let coord of coords) {
+                    path.add(new paper.Point(coord[0], coord[1]));
+                }
+
+                overlay_group.addChild(path);
+                path_count++;
+            }
+        }
+
+        geojson_layers[overlay_name] = overlay_group;
+        overlay_group.visible = false;  // Hidden by default
+        console.log('Successfully loaded GeoJSON overlay:', overlay_name, 'with', path_count, 'paths');
+        console.log('Group bounds:', overlay_group.bounds);
+        console.log('Overlay group:', overlay_group);
+    }
+
+    // Load and render all GeoJSON overlays
+    function load_geojson_overlays() {
+        for (let overlay_name in geojson_overlays) {
+            (function(name) {
+                const url = "{{url_for('slide.api_get_geojson_overlay', task_id=task_id, slide_id=slide_id, overlay_name='XXXX')}}".replace('XXXX', name);
+                $.get(url, function(geojson_data) {
+                    draw_geojson(geojson_data, name);
+                });
+            })(overlay_name);
+        }
+    }
+
+    // Slider handler for GeoJSON line width
+    $(document).on('input', '.geojson-width-slider', function() {
+        let overlay_name = $(this).data('overlay');
+        let width = parseFloat($(this).val());
+        
+        $('#width-value').text(width.toFixed(1));
+        
+        if (geojson_layers && geojson_layers[overlay_name]) {
+            let group = geojson_layers[overlay_name];
+            // Update all paths in the group
+            for (let child of group.children) {
+                if (child.strokeWidth !== undefined) {
+                    child.strokeWidth = width;
+                }
+            }
+            paper.view.update();
+        }
+    });
+
+    // Toggle button handler for GeoJSON overlays
+    $(document).on('click', '.geojson-toggle', function(e) {
+        console.log('Toggle button clicked!');
+        e.preventDefault();
+        e.stopPropagation();
+        
+        let overlay_name = $(this).data('overlay');
+        console.log('Toggling overlay:', overlay_name);
+        console.log('geojson_layers:', geojson_layers);
+        
+        if (geojson_layers && geojson_layers[overlay_name]) {
+            let new_state = !geojson_layers[overlay_name].visible;
+            geojson_layers[overlay_name].visible = new_state;
+
+            // When turning on, force current slider width (default 30) instead of GeoJSON file width.
+            if (new_state) {
+                let width_input = $(`.geojson-width-slider[data-overlay="${overlay_name}"]`).first();
+                let width = width_input.length ? parseFloat(width_input.val()) : 30.0;
+                $('#width-value').text(width.toFixed(1));
+                for (let child of geojson_layers[overlay_name].children) {
+                    if (child.strokeWidth !== undefined) {
+                        child.strokeWidth = width;
+                    }
+                }
+            }
+
+            console.log('Toggled to:', new_state);
+            $(this).toggleClass('active');
+            if (paper.view) {
+                paper.view.update();
+            }
+        } else {
+            console.log('ERROR: Overlay not found:', overlay_name, 'Available:', Object.keys(geojson_layers));
+        }
+    });
+
+    // Debug: log what we found
+    console.log('GeoJSON overlays loaded successfully');
 
 });
 </script>

--- a/phas/templates/slide/slide_view.html
+++ b/phas/templates/slide/slide_view.html
@@ -770,7 +770,12 @@ $(document).ready(function()
         // Handle markers
         let markers = paper.project.getItems({class: paper.PointText});
         for (let i = 0; i < markers.length; i++) {
-            markers[i].style.fontSize = get_width_in_canvas_units(10);
+            if(markers[i].data && markers[i].data.edge_measure) {
+                // Edge-measure labels should shrink as zoom increases.
+                markers[i].style.fontSize = zoom_paperjs_scaling_fn(8, 0, paperZoom);
+            } else {
+                markers[i].style.fontSize = get_width_in_canvas_units(10);
+            }
             markers[i].style.leading = markers[i].style.fontSize * 1.2;
         }
 
@@ -838,6 +843,11 @@ $(document).ready(function()
     };
 
     var mpp = parseFloat("{{ spacing[0] }}");
+    if(!Number.isFinite(mpp) || mpp <= 0) mpp = 0;
+    var mpp_x = parseFloat("{{ spacing[0] }}");
+    var mpp_y = parseFloat("{{ spacing[1] }}");
+    if(!Number.isFinite(mpp_x) || mpp_x <= 0) mpp_x = mpp;
+    if(!Number.isFinite(mpp_y) || mpp_y <= 0) mpp_y = mpp;
     viewer.scalebar({
         pixelsPerMeter: mpp ? (1e3 / mpp) : 0,
 	    location: OpenSeadragon.ScalebarLocation.BOTTOM_RIGHT,
@@ -2163,6 +2173,12 @@ $(document).ready(function()
         // A paper path object representing the line from the last vertex to the mouse cursor
         moving_edge = null;
 
+        // A floating text showing the current in-progress edge length
+        moving_edge_label = null;
+
+        // Labels for committed polygon edges during drawing
+        edge_labels = [];
+
         // The API that handles server communication, etc
         constructor(sroi_api) {
             this.sroi_api = sroi_api;
@@ -2178,6 +2194,62 @@ $(document).ready(function()
             let d = x_start.getDistance(x);
             let d_max = zoom_paperjs_scaling_fn(dist_screen, 0, get_image_zoomlevel());
             return (d <= d_max);
+        }
+
+        // Edge length in micrometers
+        edge_length_um(p0, p1) {
+            let dx_mm = (p1.x - p0.x) * mpp_x;
+            let dy_mm = (p1.y - p0.y) * mpp_y;
+            return 1000.0 * Math.sqrt(dx_mm * dx_mm + dy_mm * dy_mm);
+        }
+
+        // Place the label slightly "above" edge and keep offset visually stable while zooming.
+        edge_label_pos(p0, p1) {
+            let dx = p1.x - p0.x;
+            let dy = p1.y - p0.y;
+            let L = Math.sqrt(dx * dx + dy * dy);
+            let mid = new paper.Point((p0.x + p1.x) * 0.5, (p0.y + p1.y) * 0.5);
+            if(L < 1e-6) return mid;
+            let nx = -dy / L;
+            let ny = dx / L;
+            let off = zoom_paperjs_scaling_fn(14, 0, get_image_zoomlevel());
+            return new paper.Point(mid.x + nx * off, mid.y + ny * off);
+        }
+
+        edge_length_text(p0, p1) {
+            let um = this.edge_length_um(p0, p1);
+            if(!Number.isFinite(um) || um <= 0) return "n/a µm";
+            return `${um.toFixed(1)} µm`;
+        }
+
+        create_edge_label() {
+            let lbl = new paper.PointText(new paper.Point(0, 0));
+            lbl.style = {
+                fillColor: 'black',
+                fontWeight: 'bold',
+                fontSize: zoom_paperjs_scaling_fn(17, 0, get_image_zoomlevel()),
+                justification: 'center'
+            };
+            lbl.locked = true;
+            lbl.data.edge_measure = true;
+            return lbl;
+        }
+
+        set_edge_label(lbl, p0, p1) {
+            // Keep label size responsive to current zoom while drawing.
+            lbl.style.fontSize = zoom_paperjs_scaling_fn(17, 0, get_image_zoomlevel());
+            lbl.style.leading = lbl.style.fontSize * 1.2;
+            lbl.point = this.edge_label_pos(p0, p1);
+            lbl.content = this.edge_length_text(p0, p1);
+        }
+
+        clear_edge_labels() {
+            if(this.moving_edge_label) {
+                this.moving_edge_label.remove();
+                this.moving_edge_label = null;
+            }
+            this.edge_labels.forEach(function(lbl) { lbl.remove(); });
+            this.edge_labels = [];
         }
 
         // Press event handler
@@ -2196,11 +2268,16 @@ $(document).ready(function()
                 let dspc = zoom_paperjs_scaling_fn(5, 0, get_image_zoomlevel());
                 this.moving_edge.dashArray = [dspc, dspc];
                 set_paperjs_item_strokewidth(this.moving_edge, 2);
+                this.moving_edge_label = this.create_edge_label();
+                this.set_edge_label(this.moving_edge_label, x, x);
             } 
             else {
                 let p = this.curr_polygon.polygon;
                 if(p.segments.length > 2 && this.check_snap_to_closing(x, 10)) {
                     // Path is completed
+                    this.set_edge_label(this.moving_edge_label, p.lastSegment.point, p.firstSegment.point);
+                    this.edge_labels.push(this.moving_edge_label);
+                    this.moving_edge_label = null;
                     p.add(p.firstSegment.point);
 
                     // Send path to server
@@ -2211,14 +2288,19 @@ $(document).ready(function()
                     // Reset to initial state
                     this.moving_edge.remove(); 
                     this.moving_edge = null;
+                    this.clear_edge_labels();
                     this.curr_polygon = null;
 
                     // Reset mode to zoom/pan
                     update_current_mode('NAV');
                 } else {
+                    this.set_edge_label(this.moving_edge_label, p.lastSegment.point, x);
+                    this.edge_labels.push(this.moving_edge_label);
+                    this.moving_edge_label = this.create_edge_label();
                     p.add(x);
                     this.moving_edge.segments[0].point = x;
                     this.moving_edge.segments[1].point = x;
+                    this.set_edge_label(this.moving_edge_label, x, x);
                 }                
             }
 
@@ -2239,6 +2321,13 @@ $(document).ready(function()
                     }
                     else {
                         this.moving_edge.strokeColor = 'black';
+                    }
+                    if(this.moving_edge_label) {
+                        this.set_edge_label(
+                            this.moving_edge_label,
+                            this.moving_edge.segments[0].point,
+                            this.moving_edge.segments[1].point
+                        );
                     }
                     paper.view.draw();
                 }


### PR DESCRIPTION
**`slide.py`**

[1] Added backend discovery for overlay (to display - both GM/WM contour & Nuclei Morphometrics) in the slide directory:
- GeoJSON contours (*_*.geojson) - `def get_geojson_overlays(sr, slide_id, task_id)`
- Nuclei heatmaps (*_soma_density_heatmap.png, *_soma_size_heatmap.png) - `def get_nuclei_heatmap_overlays(sr, slide_id, task_id)` and `resolve_nuclei_heatmap_path(...)`

[2] Updated slide_view(...) context to pass:
- geojson_overlays
- nuclei_heatmap_overlays

[3] Added/used API endpoints for overlay fetch:
- GeoJSON: api_get_geojson_overlay(...)
- PNG heatmaps: api_get_nuclei_heatmap_overlay(...)


**`slide_view.html`**

[1] Added UI for GM/WM Contour (C) with width slider and toggle button.
- Contour Width slider
- Toggle button (GM/WM Contou (C))

[2] Added UI controls for Nuclei Morphometric above GM/WM controls:
- Opacity slider
- Toggle button (Nuclei Morphometric (N))
- Mutually exclusive checkboxes (Nuclei Density / Nuclei Size)

[3] Wired overlay behavior in JS:
- Load/draw GeoJSON via Paper.js layers
- Toggle contour visibility and apply current width immediately on toggle-on
- Load nuclei PNG as image overlay on OpenSeadragon viewer
- Enforce one nuclei overlay at a time
- Opacity slider updates nuclei overlay transparency live

[4] Updated styling/layout:
- Matched control widths
- Added spacing/positioning refinements between the two overlay groups.